### PR TITLE
Update DataFrames' Versions.toml with nix-sha256 values

### DIFF
--- a/D/DataFrames/Versions.toml
+++ b/D/DataFrames/Versions.toml
@@ -1,210 +1,280 @@
+
 ["0.11.7"]
-git-tree-sha1 = "a79e5f3756177f9135f6c2318f4d90bc40da8feb"
+  git-tree-sha1 = "a79e5f3756177f9135f6c2318f4d90bc40da8feb"
+  nix-sha256 = "0kl3n6aax0wnny81kqyxg9gfb4rzx8rqkffqaz4abd4sa5g9n1d6"
 
 ["0.12.0"]
-git-tree-sha1 = "1cc9493d9b659db1fa6d584afc3f73d74341e567"
+  git-tree-sha1 = "1cc9493d9b659db1fa6d584afc3f73d74341e567"
+  nix-sha256 = "0x6znf8wl0z7brh5khj71filjcm26aby3mghaaicq1xrlrgmq0b8"
 
 ["0.13.0"]
-git-tree-sha1 = "fff8b03ab91c5c0d6a26e8f9c666bdd439a092c9"
+  git-tree-sha1 = "fff8b03ab91c5c0d6a26e8f9c666bdd439a092c9"
+  nix-sha256 = "1arxjmaf029fblrjlkmm2grskh2xh4m3h9k9w8mppl5v2fr8lwds"
 
 ["0.13.1"]
-git-tree-sha1 = "31cca86a48add8d5cdd9457c4f75ee5577ef3488"
+  git-tree-sha1 = "31cca86a48add8d5cdd9457c4f75ee5577ef3488"
+  nix-sha256 = "0s0didd6mhy6lqpnf56w2zavlq64l1ibx90gx638795qqjlq7v8h"
 
 ["0.14.0"]
-git-tree-sha1 = "0fcb0c9914f31e0607b1965dc5a9e15c969c4806"
+  git-tree-sha1 = "0fcb0c9914f31e0607b1965dc5a9e15c969c4806"
+  nix-sha256 = "14rx8i32wi04a893qzjpnihg3p6yl0z0ycdypdncnww2lhjkg4y4"
 
 ["0.14.1"]
-git-tree-sha1 = "ad34fefb72b18a8dd5c17fab9089d11111b61935"
+  git-tree-sha1 = "ad34fefb72b18a8dd5c17fab9089d11111b61935"
+  nix-sha256 = "0xg7isha837b34kjr5piqizx7fw1kkmvhfwlbldlnhzcdrlcaxf7"
 
 ["0.15.0"]
-git-tree-sha1 = "dd11f0aed840e305050f4b49f53153d2dd622650"
+  git-tree-sha1 = "dd11f0aed840e305050f4b49f53153d2dd622650"
+  nix-sha256 = "1w4lmgh6adwfbp9pmrysg9kngij893x3fwhl4gl6gw6ws61niv3w"
 
 ["0.15.1"]
-git-tree-sha1 = "60c2820c9ae93cc33e98cd820e0b449d551c7874"
+  git-tree-sha1 = "60c2820c9ae93cc33e98cd820e0b449d551c7874"
+  nix-sha256 = "0lxag4fw5sszkzkgcrn83fhwadin17r1r409hhq53hijc06y7zj1"
 
 ["0.15.2"]
-git-tree-sha1 = "41ec35bcf49a860706924b9b3e322eed03164c83"
+  git-tree-sha1 = "41ec35bcf49a860706924b9b3e322eed03164c83"
+  nix-sha256 = "1989i1mnbbnwdgyba3kqr8ihcwcgvjjs9k9d2i7a07dgssdw48ga"
 
 ["0.16.0"]
-git-tree-sha1 = "7e032a76f3455e38660ac456791951ac2d0b1e70"
+  git-tree-sha1 = "7e032a76f3455e38660ac456791951ac2d0b1e70"
+  nix-sha256 = "1x207ik9d89ixh1fq8af0pq4jw0qm50pd9lc0jx3rf72zxvrjvdh"
 
 ["0.17.0"]
-git-tree-sha1 = "af5c8a233b838076947ef0c8f882f732ad578112"
+  git-tree-sha1 = "af5c8a233b838076947ef0c8f882f732ad578112"
+  nix-sha256 = "0w7hzwcqyfqn7g15yg2ddh3m421qywf2mgl2qxw1b15wc4ax0ch1"
 
 ["0.17.1"]
-git-tree-sha1 = "9cfed75401d25d281076eb5d82de148ac2933f9e"
+  git-tree-sha1 = "9cfed75401d25d281076eb5d82de148ac2933f9e"
+  nix-sha256 = "02m84k7anhbcfcf717k5p6j1jlwj0l79yf50n9ikq7100mrqq6cj"
 
 ["0.18.0"]
-git-tree-sha1 = "61528683a3ef43e203adb300958ef89a91492cab"
+  git-tree-sha1 = "61528683a3ef43e203adb300958ef89a91492cab"
+  nix-sha256 = "1kpafjsj1dvh5ajzsh1khgn0ssyixmck1ifsf4j2ypmvigci0lkz"
 
 ["0.18.1"]
-git-tree-sha1 = "4b83473baad52fbfe3b33b720e4fa722cdd62ce8"
+  git-tree-sha1 = "4b83473baad52fbfe3b33b720e4fa722cdd62ce8"
+  nix-sha256 = "19f83360hxq60ycw3640bzgh4b7j1wgp3bz0wh5knnl6095hkaas"
 
 ["0.18.2"]
-git-tree-sha1 = "3891a62fd843662af9f78f25bdd415530b9b9c1e"
+  git-tree-sha1 = "3891a62fd843662af9f78f25bdd415530b9b9c1e"
+  nix-sha256 = "182kf4g7z78n6rha7c1ifrn90dgdq98vr2zc67hi2izysv2z6vlm"
 
 ["0.18.3"]
-git-tree-sha1 = "279baa6358fd5e944deccab88434f69c74cfc722"
+  git-tree-sha1 = "279baa6358fd5e944deccab88434f69c74cfc722"
+  nix-sha256 = "1najgcls91zvfcm76pq85953cs393nkv309f6klabvrllxbbxq9i"
 
 ["0.18.4"]
-git-tree-sha1 = "7c0f86a01be0f77cc7f3f9096ed875f1217487e1"
+  git-tree-sha1 = "7c0f86a01be0f77cc7f3f9096ed875f1217487e1"
+  nix-sha256 = "00483xhyv01zrbblcy042n4sm955y61ypyh44bla82qjg1aki1i7"
 
 ["0.19.0"]
-git-tree-sha1 = "def266a7e5eb6f633ef4c72633d2a328b9450052"
+  git-tree-sha1 = "def266a7e5eb6f633ef4c72633d2a328b9450052"
+  nix-sha256 = "12pivz30rkg8alpj1zz86k76mjhdfhv35sxi26l1v8v5332w5yad"
 
 ["0.19.1"]
-git-tree-sha1 = "12a96f70fc126f8a308eadd4eda843dfa630bbd4"
+  git-tree-sha1 = "12a96f70fc126f8a308eadd4eda843dfa630bbd4"
+  nix-sha256 = "0i58khcg486k7affkkj43b23zrg4flmy85s9rkwp021gnal80p6b"
 
 ["0.19.2"]
-git-tree-sha1 = "48ef38bd7cf0e8fd598bda981409eb6ef4b96cbd"
+  git-tree-sha1 = "48ef38bd7cf0e8fd598bda981409eb6ef4b96cbd"
+  nix-sha256 = "13n5rcjnsgwwcq0ms7159g2p3b5a3dw1p068z5kgbkhky5n7mgwq"
 
 ["0.19.3"]
-git-tree-sha1 = "934b75a90b6cb315f9ea0df961768a02c1da1612"
+  git-tree-sha1 = "934b75a90b6cb315f9ea0df961768a02c1da1612"
+  nix-sha256 = "0fqss4jlq2849lr9iq5mxkkj2yjpp09635wyv9b93a63f475y8p9"
 
 ["0.19.4"]
-git-tree-sha1 = "271528230c65a4517522e2968c3deed76b92b998"
+  git-tree-sha1 = "271528230c65a4517522e2968c3deed76b92b998"
+  nix-sha256 = "0400bhrxyz4z9xzqypayzra9xdk84frv76rz7s8p834i1v7ldmkk"
 
 ["0.20.0"]
-git-tree-sha1 = "00136fcd39d503e66ab1b2eab800c47deaf7ca04"
+  git-tree-sha1 = "00136fcd39d503e66ab1b2eab800c47deaf7ca04"
+  nix-sha256 = "05yda3p8lz0lzy40gg8kwr3hj7nklj4b1jkx4zmy91gihrznpm3j"
 
 ["0.20.1"]
-git-tree-sha1 = "096d198e0b4afcf995187f36a50dc83f0bdbcb14"
+  git-tree-sha1 = "096d198e0b4afcf995187f36a50dc83f0bdbcb14"
+  nix-sha256 = "0wdlv9r5flmgpmv5a28l1an5icyi7a7g4nj3b8vzs5ih245hsqaw"
 
 ["0.20.2"]
-git-tree-sha1 = "7d5bf815cc0b30253e3486e8ce2b93bf9d0faff6"
+  git-tree-sha1 = "7d5bf815cc0b30253e3486e8ce2b93bf9d0faff6"
+  nix-sha256 = "0n024bk96vf3pw4q61gp4i2njq3604qpk058xzwhq42w9aisk4qi"
 
 ["0.21.0"]
-git-tree-sha1 = "1b4d832288e2d919eeaccdf1d9af7a8a57d773d6"
+  git-tree-sha1 = "1b4d832288e2d919eeaccdf1d9af7a8a57d773d6"
+  nix-sha256 = "1faa4y26xz775pmqyn8d8ygy81x3910qvg4mba00z5sgqynw4n5s"
 
 ["0.21.1"]
-git-tree-sha1 = "a3b230f7c0db4ce95d14d2026777e27c1b0f63db"
+  git-tree-sha1 = "a3b230f7c0db4ce95d14d2026777e27c1b0f63db"
+  nix-sha256 = "1jrc94vc7mvp0aklgf120izjb8nz7ph1p5bmfi1rjvnw9nab4412"
 
 ["0.21.2"]
-git-tree-sha1 = "02f08ae77249b7f6d4186b081a016fb7454c616f"
+  git-tree-sha1 = "02f08ae77249b7f6d4186b081a016fb7454c616f"
+  nix-sha256 = "0j6af7h21zfrh8r1f4b19kl9i4p683wcjcng5b2kbnwvf12bjfcv"
 
 ["0.21.3"]
-git-tree-sha1 = "e516e72bfb40809b7709cda7bfb39e82ec492d68"
+  git-tree-sha1 = "e516e72bfb40809b7709cda7bfb39e82ec492d68"
+  nix-sha256 = "0k2z1cm8jsrm94ar70km4dpjjhjgphyzz7r9gfhijzm32lz5szh4"
 
 ["0.21.4"]
-git-tree-sha1 = "d4436b646615928b634b37e99a3288588072f851"
+  git-tree-sha1 = "d4436b646615928b634b37e99a3288588072f851"
+  nix-sha256 = "1ks42bcn6dcg1nhd7gnzhbxs00sh4gsgr6n4k6ham3xw8ji77vcn"
 
 ["0.21.5"]
-git-tree-sha1 = "7721fa8c42ccb8f1ea7f99f6c2e94686892dd3b7"
+  git-tree-sha1 = "7721fa8c42ccb8f1ea7f99f6c2e94686892dd3b7"
+  nix-sha256 = "015q6fklfg8rgvqdlawziwkc39g8mypy7jv53qhc3b51srpn6yn4"
 
 ["0.21.6"]
-git-tree-sha1 = "4fe99dbfb5201c5766d20d32a65209434347fd58"
+  git-tree-sha1 = "4fe99dbfb5201c5766d20d32a65209434347fd58"
+  nix-sha256 = "1df894abv5w4wq8h5kjpj4lhww0kcld8pn860p42g194ffzi8b19"
 
 ["0.21.7"]
-git-tree-sha1 = "a7c1c9a6e47a92321bbc9d500dab9b04cc4a6a39"
+  git-tree-sha1 = "a7c1c9a6e47a92321bbc9d500dab9b04cc4a6a39"
+  nix-sha256 = "0k0is2x76pcnmg2l1jxhcvmyp2lj0skx4lzd9i0ibi4zlp0a43in"
 
 ["0.21.8"]
-git-tree-sha1 = "ecd850f3d2b815431104252575e7307256121548"
+  git-tree-sha1 = "ecd850f3d2b815431104252575e7307256121548"
+  nix-sha256 = "0q9nlr8cjcicmrva4rm8q3y5sgywckwxk9d0js6czy93j9csw9nc"
 
 ["0.22.0"]
-git-tree-sha1 = "3bd2f94213ea7c5cc44c84f25f364a08207d9d71"
+  git-tree-sha1 = "3bd2f94213ea7c5cc44c84f25f364a08207d9d71"
+  nix-sha256 = "12s7cxv58cvgmb4mwqsmvm1afidxc7zfhq82sdx0gk3k2whfdcry"
 
 ["0.22.1"]
-git-tree-sha1 = "20159837c2e5e196793a313cd700b8199fd8f985"
+  git-tree-sha1 = "20159837c2e5e196793a313cd700b8199fd8f985"
+  nix-sha256 = "1j42m4hwzbaiba8mk45496ikdhlr57xvqb2krr2ind0z0r1sw62w"
 
 ["0.22.2"]
-git-tree-sha1 = "b46e1deb4592a5df7416b10dfcd6b01fb194ab9a"
+  git-tree-sha1 = "b46e1deb4592a5df7416b10dfcd6b01fb194ab9a"
+  nix-sha256 = "0mvjkhf21ka0pbfh5v9ci3v3dlrxhi6r34rwg9bj7qxl4bljil32"
 
 ["0.22.3"]
-git-tree-sha1 = "fdb7d95be093cf72598c5df75ecebed54e911380"
+  git-tree-sha1 = "fdb7d95be093cf72598c5df75ecebed54e911380"
+  nix-sha256 = "042wxs4nvfn1i5cc56vjwjfjr62da06qqyr6k3m8ikliwrv69i0x"
 
 ["0.22.4"]
-git-tree-sha1 = "c5f9f2385a52e35c75efd90911091f8a749177a5"
+  git-tree-sha1 = "c5f9f2385a52e35c75efd90911091f8a749177a5"
+  nix-sha256 = "1wx7fy77prrpywivlxi7dqflzwwk9z8aa6m5dsgmjacldigjn30j"
 
 ["0.22.5"]
-git-tree-sha1 = "b0db5579803eabb33f1274ca7ca2f472fdfb7f2a"
+  git-tree-sha1 = "b0db5579803eabb33f1274ca7ca2f472fdfb7f2a"
+  nix-sha256 = "0k7p6xrgj7lsa25jifs4zq94kqfxfgl1qjg2yyp5sjq0nwm2gb37"
 
 ["0.22.6"]
-git-tree-sha1 = "6b6dcb8c1a32c2151c5110e0e11fecff1c50dfca"
+  git-tree-sha1 = "6b6dcb8c1a32c2151c5110e0e11fecff1c50dfca"
+  nix-sha256 = "0dalv1gy5lv8xcsnsiq2zqkzw6phlrnyqngkm6y21iij5xqcnqbv"
 
 ["0.22.7"]
-git-tree-sha1 = "d50972453ef464ddcebdf489d11885468b7b83a3"
+  git-tree-sha1 = "d50972453ef464ddcebdf489d11885468b7b83a3"
+  nix-sha256 = "1v8r799mi0wfc0g5rkjgw6kbdyk0ghk2khy5n62f1wq5z1801swj"
 
 ["1.0.0"]
-git-tree-sha1 = "56ff5833e5b755d2db654479993e949e73606b64"
+  git-tree-sha1 = "56ff5833e5b755d2db654479993e949e73606b64"
+  nix-sha256 = "1qf49f7wd26bg2apm99n91zdqrgrcc87q869nvsxkb1fq765gpli"
 
 ["1.0.1"]
-git-tree-sha1 = "78028b8c1c5147515e0a367e6bbe679fc86ff085"
+  git-tree-sha1 = "78028b8c1c5147515e0a367e6bbe679fc86ff085"
+  nix-sha256 = "1izcrn450q2mwdpsz548ciz69wvf3yynji5fdi61d8zb9a5xhbd1"
 
 ["1.0.2"]
-git-tree-sha1 = "6e5452d9cf401ed9048e1cde93815be53d951079"
+  git-tree-sha1 = "6e5452d9cf401ed9048e1cde93815be53d951079"
+  nix-sha256 = "0vgj6vp83l9z4m9qzja62ilh8ajgjfq4x5v5adm184snnbylvmpw"
 
 ["1.1.0"]
-git-tree-sha1 = "ce0245eff066b386144e39c022052c3994fb4fce"
+  git-tree-sha1 = "ce0245eff066b386144e39c022052c3994fb4fce"
+  nix-sha256 = "1izcg6c22azq2djpy8fqb1inf5kpqidp5xw2mdlnd8wb0j9213v3"
 
 ["1.1.1"]
-git-tree-sha1 = "66ee4fe515a9294a8836ef18eea7239c6ac3db5e"
+  git-tree-sha1 = "66ee4fe515a9294a8836ef18eea7239c6ac3db5e"
+  nix-sha256 = "0ab03l9q9vmc176711hp0adc456fphh0d762fv6hcvzvhms4xjkz"
 
 ["1.2.0"]
-git-tree-sha1 = "1dadfca11c0e08e03ab15b63aaeda55266754bad"
+  git-tree-sha1 = "1dadfca11c0e08e03ab15b63aaeda55266754bad"
+  nix-sha256 = "09nqkhhv4djd83i2b76z1pzc0flaiym85gzx093qmpjxvnrq28wk"
 
 ["1.2.1"]
-git-tree-sha1 = "a19645616f37a2c2c3077a44bc0d3e73e13441d7"
+  git-tree-sha1 = "a19645616f37a2c2c3077a44bc0d3e73e13441d7"
+  nix-sha256 = "0s6185va8dg1prd9yyi04v58288qis9q9lzvs2h6pl9xp37agz8z"
 
 ["1.2.2"]
-git-tree-sha1 = "d785f42445b63fc86caa08bb9a9351008be9b765"
+  git-tree-sha1 = "d785f42445b63fc86caa08bb9a9351008be9b765"
+  nix-sha256 = "1bk0amrghgjrkyn1mm4ac23swwbgszl1d0qyl9137qj5zvv9dasp"
 
 ["1.3.0"]
-git-tree-sha1 = "2e993336a3f68216be91eb8ee4625ebbaba19147"
+  git-tree-sha1 = "2e993336a3f68216be91eb8ee4625ebbaba19147"
+  nix-sha256 = "1131f0ajhnl5sxj5zdg8jz8vk9sisic647is7ksdl1hzdn75z04n"
 
 ["1.3.1"]
-git-tree-sha1 = "cfdfef912b7f93e4b848e80b9befdf9e331bc05a"
+  git-tree-sha1 = "cfdfef912b7f93e4b848e80b9befdf9e331bc05a"
+  nix-sha256 = "0k79kv1m19cbhp2qgn8dm74ssd1vj2jcn0ncd3d1vvlj1n2kvlkz"
 
 ["1.3.2"]
-git-tree-sha1 = "ae02104e835f219b8930c7664b8012c93475c340"
+  git-tree-sha1 = "ae02104e835f219b8930c7664b8012c93475c340"
+  nix-sha256 = "1nx8dx3yb87gmyfpjcmbcximbf9fj6cxpcl0pln0hlw9cpbxyzx7"
 
 ["1.3.3"]
-git-tree-sha1 = "6c19003824cbebd804a51211fd3bbd81bf1ecad5"
+  git-tree-sha1 = "6c19003824cbebd804a51211fd3bbd81bf1ecad5"
+  nix-sha256 = "0cbbndbpzqgpmzkans5dkp2ialzywcliw64hsj60xkhydibaqqvc"
 
 ["1.3.4"]
-git-tree-sha1 = "daa21eb85147f72e41f6352a57fccea377e310a9"
+  git-tree-sha1 = "daa21eb85147f72e41f6352a57fccea377e310a9"
+  nix-sha256 = "1wr8fm4x2yn8wjglfypfwb6dkbfcjlmc77cp7562x9nb3pvmhayb"
 
 ["1.3.5"]
-git-tree-sha1 = "6bce52b2060598d8caaed807ec6d6da2a1de949e"
+  git-tree-sha1 = "6bce52b2060598d8caaed807ec6d6da2a1de949e"
+  nix-sha256 = "037nix2660agm2n2xrzd7cr5ayns6dfiv176vjyj1kc9y53a97c4"
 
 ["1.3.6"]
-git-tree-sha1 = "db2a9cb664fcea7836da4b414c3278d71dd602d2"
+  git-tree-sha1 = "db2a9cb664fcea7836da4b414c3278d71dd602d2"
+  nix-sha256 = "01ybc1ckn5wi7kwp29g5ms4m3g650856z4xv71racbdr8475pmg5"
 
 ["1.4.0"]
-git-tree-sha1 = "1df8f72c05cc83c1e6907f393312d3b009bcc3d4"
+  git-tree-sha1 = "1df8f72c05cc83c1e6907f393312d3b009bcc3d4"
+  nix-sha256 = "0pjng06df2drxvf3vizcakv3kvjypsxr1fadrpv2j2l6z16a9d9p"
 
 ["1.4.1"]
-git-tree-sha1 = "558078b0b78278683a7445c626ee78c86b9bb000"
+  git-tree-sha1 = "558078b0b78278683a7445c626ee78c86b9bb000"
+  nix-sha256 = "00vkz69v9aknwjxngm8jn9v43qm4pi7m5zix6vibp1hyqy522idc"
 
 ["1.4.2"]
-git-tree-sha1 = "5b93f1b47eec9b7194814e40542752418546679f"
+  git-tree-sha1 = "5b93f1b47eec9b7194814e40542752418546679f"
+  nix-sha256 = "0769fdihi1f6mp0xibllw0qmlsrf9cxhny58pv0x8fc2vkbvgn2w"
 
 ["1.4.3"]
-git-tree-sha1 = "0f44494fe4271cc966ac4fea524111bef63ba86c"
+  git-tree-sha1 = "0f44494fe4271cc966ac4fea524111bef63ba86c"
+  nix-sha256 = "0mxpigp8b9gjbvp3sbyka4cv26jdd8s5qkhz9i9s79c3czkw4ri4"
 
 ["1.4.4"]
-git-tree-sha1 = "d4f69885afa5e6149d0cab3818491565cf41446d"
+  git-tree-sha1 = "d4f69885afa5e6149d0cab3818491565cf41446d"
+  nix-sha256 = "121588xcwsiappvxqfi2xsnglbqfnavzcgik8bj4pzpivhhr6kcf"
 
 ["1.5.0"]
-git-tree-sha1 = "aa51303df86f8626a962fccb878430cdb0a97eee"
+  git-tree-sha1 = "aa51303df86f8626a962fccb878430cdb0a97eee"
+  nix-sha256 = "0cllsjjwy76hc8y0qlqnjyia4zjab1pv1x3jakb1q49wk7rbnybg"
 
 ["1.6.0"]
-git-tree-sha1 = "089d29c0fc00a190661517e4f3cba5dcb3fd0c08"
-yanked = true
+  git-tree-sha1 = "089d29c0fc00a190661517e4f3cba5dcb3fd0c08"
+  nix-sha256 = "1sf342xjzal5wxspykqdqqdm464ibmxwx9wqrsj408kdv6awxlbw"
 
 ["1.6.1"]
-git-tree-sha1 = "04c738083f29f86e62c8afc341f0967d8717bdb8"
+  git-tree-sha1 = "04c738083f29f86e62c8afc341f0967d8717bdb8"
+  nix-sha256 = "1x68j4w4z606dqbjqnnmwhdj0rpin4wd06g8np32x4yqca97q483"
 
 ["1.7.0"]
-git-tree-sha1 = "fb61b4812c49343d7ef0b533ba982c46021938a6"
+  git-tree-sha1 = "fb61b4812c49343d7ef0b533ba982c46021938a6"
+  nix-sha256 = "0v84d2rshk7mrd31w9q47hj1ld2xz4na07cd9d7mxic1i9g08g2j"
 
 ["1.7.1"]
-git-tree-sha1 = "a37ac0840a1196cd00317b57e39d6586bf0fd6f6"
+  git-tree-sha1 = "a37ac0840a1196cd00317b57e39d6586bf0fd6f6"
+  nix-sha256 = "1kkhpncbjyhc1mr81zi57brrssgqqa4yskbqn0wfhq5055c6cbjh"
 
 ["1.8.0"]
-git-tree-sha1 = "c967271c27a95160e30432e011b58f42cd7501b5"
+  git-tree-sha1 = "c967271c27a95160e30432e011b58f42cd7501b5"
+  nix-sha256 = "0jvdfg7gm97glnsy1yxyp9s4db568qmljiyyax7xns1vl6b11ng4"
 
 ["1.8.1"]
-git-tree-sha1 = "d8928e9169ff76c6281f39a659f9bca3a573f24c"
+  git-tree-sha1 = "d8928e9169ff76c6281f39a659f9bca3a573f24c"
+  nix-sha256 = "13h4jvwv51khgw1wl9j66wl6mdqrs8wwqrmxm3gw2k0n600cilrq"
 
 ["1.8.2"]
-git-tree-sha1 = "5fab31e2e01e70ad66e3e24c968c264d1cf166d6"
+  git-tree-sha1 = "5fab31e2e01e70ad66e3e24c968c264d1cf166d6"
+  nix-sha256 = "1686dn54jz040ng3ibrzvdz6kbv2fsamdgd074ljqk1axwmqflf2"


### PR DESCRIPTION
The nix hashes for DataFrames have been missing as the repo was unreachable (as per failures.yml)